### PR TITLE
process: skip lines that contains the same words but in different order

### DIFF
--- a/cli/src/dataset.rs
+++ b/cli/src/dataset.rs
@@ -60,7 +60,7 @@ fn process(path: &Path, dataset: Dataset) -> Result<()> {
                 .inspect(
                     om,
                     &Source::from_pathbuf(fail.to_path_buf()),
-                    &mut std::collections::HashSet::new(),
+                    &mut logreduce_model::unordered::KnownLines::new(),
                 )
                 .collect::<Result<Vec<AnomalyContext>>>()?;
             let anomalies_count = anomalies.len();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -319,7 +319,7 @@ fn process_live(output_mode: OutputMode, content: &Content, model: &Model) -> Re
                 match index.get_processor(
                     output_mode,
                     &source,
-                    &mut std::collections::HashSet::new(),
+                    &mut logreduce_model::unordered::KnownLines::new(),
                 ) {
                     Ok(mut processor) => {
                         for anomaly in processor.by_ref() {

--- a/model/benches/bench-model.rs
+++ b/model/benches/bench-model.rs
@@ -20,7 +20,7 @@ pub fn model_process(c: &mut Criterion) {
     c.bench_function("anomalies_from_reader", |b| {
         b.iter(|| {
             let data = std::io::Cursor::new(&target);
-            let mut skip_lines = std::collections::HashSet::new();
+            let mut skip_lines = logreduce_model::unordered::KnownLines::new();
             let processor = logreduce_model::process::ChunkProcessor::new(
                 black_box(data),
                 &index,

--- a/model/src/unordered.rs
+++ b/model/src/unordered.rs
@@ -1,0 +1,49 @@
+// Copyright (C) 2023 Red Hat
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module provides an unordered bag of lines
+
+use itertools::Itertools;
+use std::collections::HashSet;
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+struct UnorderedLine(Vec<String>);
+
+impl UnorderedLine {
+    fn from_str(line: &str) -> UnorderedLine {
+        UnorderedLine(
+            line.split(' ')
+                .sorted()
+                .map(|word| word.to_string())
+                .collect(),
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct KnownLines(HashSet<UnorderedLine>);
+
+impl KnownLines {
+    pub fn new() -> KnownLines {
+        KnownLines(HashSet::new())
+    }
+
+    pub fn insert(&mut self, line: &str) -> bool {
+        let uline = UnorderedLine::from_str(line);
+        self.0.insert(uline)
+    }
+}
+
+impl Default for KnownLines {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[test]
+fn test_known_lines() {
+    let mut skip_lines = KnownLines::new();
+    assert_eq!(true, skip_lines.insert("first line"));
+    assert_eq!(false, skip_lines.insert("first line"));
+    assert_eq!(false, skip_lines.insert("line first"));
+}


### PR DESCRIPTION
When processing podman debug logs, the annotations are printed in random order. This change prevents processing the same content over and over again.