### PR TITLE
Keep Content data in report

### DIFF
--- a/crates/cli/src/dataset.rs
+++ b/crates/cli/src/dataset.rs
@@ -11,7 +11,7 @@ use std::iter::zip;
 use std::path::Path;
 
 use logreduce_model::env::Env;
-use logreduce_model::{AnomalyContext, Content, IndexName, Model, Source};
+use logreduce_model::{content_from_pathbuf, AnomalyContext, IndexName, Model, Source};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct DatasetAnomaly {
@@ -55,7 +55,7 @@ fn process(env: &Env, path: &Path, dataset: Dataset) -> Result<()> {
         (Some(good), Some(fail)) => {
             let model = Model::train(
                 env,
-                [Content::from_pathbuf(good.to_path_buf())].to_vec(),
+                [content_from_pathbuf(good.to_path_buf())].to_vec(),
                 logreduce_model::hashing_index::new,
             )?;
             let index = model.get_index(&IndexName("".to_string())).unwrap();

--- a/crates/model/src/files.rs
+++ b/crates/model/src/files.rs
@@ -9,28 +9,26 @@ use std::path::Path;
 use crate::env::Env;
 use crate::{Baselines, Content, Input, Source};
 
-impl Content {
-    #[tracing::instrument(level = "debug")]
-    pub fn from_path(path: &Path) -> Result<Content> {
-        let src = Source::Local(0, path.to_path_buf());
+#[tracing::instrument(level = "debug")]
+pub fn content_from_path(path: &Path) -> Result<Content> {
+    let src = Source::Local(0, path.to_path_buf());
 
-        if path.is_dir() {
-            Ok(Content::Directory(src))
-        } else if path.is_file() {
-            Ok(Content::File(src))
-        } else {
-            Err(anyhow::anyhow!("Unknown path: {:?}", path))
-        }
+    if path.is_dir() {
+        Ok(Content::Directory(src))
+    } else if path.is_file() {
+        Ok(Content::File(src))
+    } else {
+        Err(anyhow::anyhow!("Unknown path: {:?}", path))
     }
+}
 
-    #[tracing::instrument(level = "debug", skip(env))]
-    pub fn discover_baselines_from_path(env: &Env, path: &Path) -> Result<Baselines> {
-        // TODO: implement discovery by looking for common rotated file names.
-        let mut path_str = path.to_path_buf().into_os_string().into_string().unwrap();
-        path_str.push_str(".0");
-        let baseline = Content::from_input(env, Input::Path(path_str))?;
-        Ok(vec![baseline])
-    }
+#[tracing::instrument(level = "debug", skip(env))]
+pub fn discover_baselines_from_path(env: &Env, path: &Path) -> Result<Baselines> {
+    // TODO: implement discovery by looking for common rotated file names.
+    let mut path_str = path.to_path_buf().into_os_string().into_string().unwrap();
+    path_str.push_str(".0");
+    let baseline = crate::content_from_input(env, Input::Path(path_str))?;
+    Ok(vec![baseline])
 }
 
 pub fn file_open(path: &Path) -> Result<crate::reader::DecompressReader> {

--- a/crates/model/src/prow.rs
+++ b/crates/model/src/prow.rs
@@ -9,12 +9,12 @@ use url::Url;
 
 use crate::env::Env;
 use crate::{Baselines, Content, Source};
-use prow_build::{ProwID, StoragePath, StorageType};
+use prow_build::{StoragePath, StorageType};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Build {
     pub url: Url,
-    pub uid: ProwID,
+    pub uid: String,
     pub job_name: String,
     pub project: String,
     pub pr: u64,
@@ -141,7 +141,7 @@ impl Build {
         let url = build.url.join(&br.path)?;
         Ok(Build {
             url: url.clone(),
-            uid: br.uid,
+            uid: br.uid.into(),
             job_name: build.job_name.clone(),
             project: "tbd".into(),
             pr: 0,

--- a/crates/model/src/prow.rs
+++ b/crates/model/src/prow.rs
@@ -56,14 +56,12 @@ fn test_parse_prow_url() {
     );
 }
 
-impl Content {
-    pub fn from_prow_url(url: &Url) -> Option<Result<Content>> {
-        match url.authority() {
-            "prow.ci.openshift.org" => {
-                parse_prow_url(url).map(|res| res.map(|build| Content::Prow(Box::new(build))))
-            }
-            _ => None,
+pub fn content_from_prow_url(url: &Url) -> Option<Result<Content>> {
+    match url.authority() {
+        "prow.ci.openshift.org" => {
+            parse_prow_url(url).map(|res| res.map(|build| Content::Prow(Box::new(build))))
         }
+        _ => None,
     }
 }
 

--- a/crates/model/src/urls.rs
+++ b/crates/model/src/urls.rs
@@ -11,20 +11,18 @@ lazy_static::lazy_static! {
     static ref CACHE: logreduce_cache::Cache = logreduce_cache::Cache::new().expect("Cache");
 }
 
-impl Content {
-    #[tracing::instrument(level = "debug", skip(env))]
-    pub fn from_url(env: &Env, url: Url) -> Result<Content> {
-        if !url.has_authority() {
-            Err(anyhow::anyhow!("Bad url {}", url))
-        } else if let Some(content) = Content::from_zuul_url(env, &url) {
-            content
-        } else if let Some(content) = Content::from_prow_url(&url) {
-            content
-        } else if url.as_str().ends_with('/') {
-            Ok(Content::Directory(Source::Remote(0, url)))
-        } else {
-            Ok(Content::File(Source::Remote(0, url)))
-        }
+#[tracing::instrument(level = "debug", skip(env))]
+pub fn content_from_url(env: &Env, url: Url) -> Result<Content> {
+    if !url.has_authority() {
+        Err(anyhow::anyhow!("Bad url {}", url))
+    } else if let Some(content) = crate::zuul::content_from_zuul_url(env, &url) {
+        content
+    } else if let Some(content) = crate::prow::content_from_prow_url(&url) {
+        content
+    } else if url.as_str().ends_with('/') {
+        Ok(Content::Directory(Source::Remote(0, url)))
+    } else {
+        Ok(Content::File(Source::Remote(0, url)))
     }
 }
 

--- a/crates/model/src/zuul.rs
+++ b/crates/model/src/zuul.rs
@@ -227,14 +227,10 @@ fn get_zuul_api_url(url: &'_ Url) -> Option<Result<(Url, &'_ str)>> {
     })
 }
 
-impl Content {
-    pub fn from_zuul_url(env: &Env, url: &Url) -> Option<Result<Content>> {
-        get_zuul_api_url(url).map(|res| {
-            res.and_then(|(api, uid)| {
-                get_build(env, &api, uid).map(|build| new_content(api, build))
-            })
-        })
-    }
+pub fn content_from_zuul_url(env: &Env, url: &Url) -> Option<Result<Content>> {
+    get_zuul_api_url(url).map(|res| {
+        res.and_then(|(api, uid)| get_build(env, &api, uid).map(|build| new_content(api, build)))
+    })
 }
 
 #[test]
@@ -298,7 +294,7 @@ fn test_zuul_api() -> Result<()> {
         .create();
 
     crate::reader::drop_url(&env, 0, &url.join(api_path)?)?;
-    let content = Content::from_zuul_url(&env, &build_url).unwrap()?;
+    let content = content_from_zuul_url(&env, &build_url).unwrap()?;
     let expected = Content::Zuul(Box::new(ZuulBuild {
         per_project: false,
         api: url.join("/zuul/api/")?,

--- a/crates/prow/src/prow_build.rs
+++ b/crates/prow/src/prow_build.rs
@@ -88,6 +88,14 @@ impl From<&str> for ProwID {
     }
 }
 
+impl From<ProwID> for String {
+    /// Converts to this type from the input type.
+    #[inline]
+    fn from(pid: ProwID) -> String {
+        pid.0
+    }
+}
+
 impl From<&str> for StorageType {
     /// Converts to this type from the input type.
     #[inline]

--- a/crates/report/src/report.rs
+++ b/crates/report/src/report.rs
@@ -67,6 +67,23 @@ impl std::fmt::Display for ZuulBuild {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProwBuild {
+    pub url: Url,
+    pub uid: String,
+    pub job_name: String,
+    pub project: String,
+    pub pr: u64,
+    pub storage_type: String,
+    pub storage_path: String,
+}
+
+impl std::fmt::Display for ProwBuild {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.url.as_str())
+    }
+}
+
 /// The location of the log lines, and the relative prefix length.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Source {

--- a/crates/report/src/report.rs
+++ b/crates/report/src/report.rs
@@ -15,8 +15,8 @@ use url::Url;
 pub struct Report {
     pub created_at: SystemTime,
     pub run_time: Duration,
-    pub target: String,
-    pub baselines: Vec<String>,
+    pub target: Content,
+    pub baselines: Vec<Content>,
     pub log_reports: Vec<LogReport>,
     pub index_reports: HashMap<IndexName, IndexReport>,
     pub index_errors: Vec<Vec<Source>>,
@@ -81,6 +81,30 @@ pub struct ProwBuild {
 impl std::fmt::Display for ProwBuild {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.url.as_str())
+    }
+}
+
+/// A source of log lines.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum Content {
+    File(Source),
+    Directory(Source),
+    Zuul(Box<ZuulBuild>),
+    Prow(Box<ProwBuild>),
+    LocalZuulBuild(PathBuf, Box<ZuulBuild>),
+}
+
+impl std::fmt::Display for Content {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Content::File(src) => write!(f, "File({})", src),
+            Content::Directory(src) => write!(f, "Directory({})", src),
+            Content::Zuul(build) => write!(f, "Zuul({})", build),
+            Content::Prow(build) => write!(f, "Prow({})", build.url.as_str()),
+            Content::LocalZuulBuild(src, _build) => {
+                write!(f, "LocalZuulBuild({:?})", src.as_os_str())
+            }
+        }
     }
 }
 

--- a/crates/report/src/report.rs
+++ b/crates/report/src/report.rs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 pub use logreduce_tokenizer::index_name::IndexName;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
+use url::Url;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Report {
@@ -43,11 +45,33 @@ impl Report {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ZuulBuild {
+    pub api: Url,
+    pub per_project: bool,
+    pub uuid: String,
+    pub job_name: String,
+    pub project: String,
+    pub branch: String,
+    pub result: String,
+    pub pipeline: String,
+    pub log_url: Url,
+    pub ref_url: Url,
+    pub end_time: DateTime<Utc>,
+    pub change: u64,
+}
+
+impl std::fmt::Display for ZuulBuild {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}build/{}", self.api.as_str(), self.uuid)
+    }
+}
+
 /// The location of the log lines, and the relative prefix length.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Source {
     Local(usize, PathBuf),
-    Remote(usize, url::Url),
+    Remote(usize, Url),
 }
 
 impl Source {


### PR DESCRIPTION
This change recover the full Content data type inside the logreduce report crate.